### PR TITLE
feat: add publish target option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,16 @@ The target zipped file name.
 
 Publish or not after upload (true / false)
 
+### `target`
+
+Publish target. 'default' or 'trustedTesters'
+
 ## Outputs
 
 ## Example usage
 
 ```
-uses: Klemensas/chrome-extension-upload-action@$VERSION
+uses: Airfordable/chrome-extension-upload-action@$VERSION
 with:
   refresh-token: 'xxxxxxxxxxxxxxxxxxxxxx'
   client-id: 'xxxxxxxxxxxxx'
@@ -42,4 +46,5 @@ with:
   file-name: './extension.zip'
   app-id: 'xzc12xzc21cx23'
   publish: true
+  target: trustedTesters
 ```

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   publish:
     description: True Or False to publish after upload
     required: true
+  target:
+    description: Publish target. 'default' or 'trustedTesters'
+    required: true
 runs:
   using: docker
   image: Dockerfile
@@ -32,3 +35,4 @@ runs:
     - ${{ inputs.file-name }}
     - ${{ inputs.app-id }}
     - ${{ inputs.publish }}
+    - ${{ inputs.target }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ then
   -X POST \
   -T $4 \
   -v https://www.googleapis.com/upload/chromewebstore/v1.1/items/$5/publish \
-  -d publishTarget=default \
+  -d publishTarget=$7 \
   | \
   jq -r '.publishState'`
 


### PR DESCRIPTION
Added an input for the extension publish target: `default` or `trustedTesters`.
`trustedTesters` publishes the extension to trusted testers rather than the public.